### PR TITLE
Implement YouTube Shorts Element Hider script

### DIFF
--- a/youtube/short-blocker.user.js
+++ b/youtube/short-blocker.user.js
@@ -1,0 +1,36 @@
+// ==UserScript==
+// @name         YouTube Minimal Element Blocker
+// @match        *://m.youtube.com/*
+// @match        *://www.youtube.com/*
+// @run-at       document-end
+// @grant        none
+// ==/UserScript==
+
+(function () {
+  const selectors = [
+    'ytd-rich-section-renderer',          // Shorts shelf (desktop)
+    'ytd-reel-shelf-renderer',
+    'ytd-guide-entry-renderer a[title="Shorts"]',
+    '.pivot-bar-item-tab.pivot-shorts',   // Shorts tab (mobile)
+    'ytm-rich-item-renderer.is-shorts',
+    '.reel-shelf-items',
+    '.reel-shelf-header'
+  ];
+
+  const nuke = () => {
+    selectors.forEach(sel => {
+      document.querySelectorAll(sel).forEach(el => {
+        el.style.display = 'none';
+      });
+    });
+  };
+
+  // chạy ngay
+  nuke();
+
+  // YouTube thích load lại DOM như lên cơn, nên ta canh tiếp
+  new MutationObserver(nuke).observe(document.body, {
+    childList: true,
+    subtree: true
+  });
+})();


### PR DESCRIPTION
This user script hides various elements related to YouTube Shorts on both desktop and mobile versions, ensuring a minimal viewing experience.

Close issue #2